### PR TITLE
trackEnd is emitted for every TrackEndEvent from Lavalink....

### DIFF
--- a/build/structures/Player.js
+++ b/build/structures/Player.js
@@ -339,6 +339,7 @@ class Player extends EventEmitter {
     }
 
     async trackEnd(player, track, payload) {
+        this.aqua.emit("trackEnd", player, track, payload);
         this.addToPreviousTrack(track);
         if (this.shouldDeleteMessage && this.nowPlayingMessage) {
             try {


### PR DESCRIPTION
passing the full payload (including reason) for downstream.