### PR TITLE
Fix: Correct malformed URL in Client-Name header

### DIFF
--- a/build/structures/Node.js
+++ b/build/structures/Node.js
@@ -80,7 +80,7 @@ class Node {
     const headers = Object.create(null)
     headers.Authorization = this.password
     headers['User-Id'] = this.aqua.clientId
-    headers['Client-Name'] = `Aqua/${this.aqua.version} (https://github.com/ToddyTheNoobDud/AquaLink)`
+    headers['Client-Name'] = `Aqua/${this.aqua.version} https://github.com/ToddyTheNoobDud/AquaLink`
     if (this.sessionId) headers['Session-Id'] = this.sessionId
     return headers
   }

--- a/package.json
+++ b/package.json
@@ -55,8 +55,8 @@
       "url": "https://github.com/SoulDevs"
     },
     {
-      "name": "bob (asynco)",
-      "url": "https://github.com/asynico"
+      "name": "southctrl",
+      "url": "https://github.com/southctrl"
     }
   ],
   "maintainers": [


### PR DESCRIPTION

This pull request addresses the URL formatting of the `Client-Name` header sent upon WebSocket connection. The URL was previously formatted with parentheses causing log parsers and making them unclickable in some places.

Before

The `Client-Name` header is sent as: \\ `Aqua/[version] (https://github.com/ToddyTheNoobDud/AquaLink)`

This created logs like this, with the URL parsed as `https://github.com/ToddyTheNoobDud/AquaLink)` when clicked.

After

The parentheses were removed from the header sent in `build/structures/Node.js`. The header now is: \\ `Aqua/[version] https://github.com/ToddyTheNoobDud/AquaLink`

This allows the URL to be parsed correctly and usable in logs and other applications. The change is made to the built version as the original source is not accessible in the repo.